### PR TITLE
Fix UTF-8 data, and potential stalls.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -67,42 +67,46 @@ Parser.prototype._write = function (chunk, encoding, cb) {
 
   this._buffer = Buffer.concat([this._buffer, chunk]);
 
-  if (this._collectingContent === -1) {
-    var idxTerminator = bufferIndexOf(this._buffer, HEADER_TERMINATOR);
-    if (idxTerminator === -1) {
-      return cb(null);
-    }
+  while (true) {
 
-    var info;
-    try {
-      info = this.parseHeader(this._buffer.slice(0, idxTerminator).toString());
-    } catch (err) {
-      return cb(err);
-    }
+    if (this._collectingContent === -1) {
 
-    this._headerData = info;
-    this._buffer = this._buffer.slice(idxTerminator + HEADER_TERMINATOR.length);
+      var idxTerminator = bufferIndexOf(this._buffer, HEADER_TERMINATOR);
+      if (idxTerminator === -1) {
+        return cb(null);
+      }
 
-    if (this._headerData.contentLength === 0) {
+      var info;
+      try {
+        info = this.parseHeader(this._buffer.slice(0, idxTerminator).toString());
+      } catch (err) {
+        return cb(err);
+      }
+
+      this._headerData = info;
+      this._buffer = this._buffer.slice(idxTerminator + HEADER_TERMINATOR.length);
+
+      if (this._headerData.contentLength === 0) {
+        this._emitMessage(this._headerData.message);
+      } else {
+        this._collectingContent = this._headerData.contentLength;
+      }
+
+    } else {
+
+      if (this._collectingContent > this._buffer.length) {
+        return cb(null);
+      }
+
+      this._headerData.message.content = this._buffer.slice(0, this._collectingContent);
       this._emitMessage(this._headerData.message);
-      return cb(null);
+
+      this._buffer = this._buffer.slice(this._collectingContent);
+      this._collectingContent = -1;
+
     }
 
-    this._collectingContent = this._headerData.contentLength;
-
   }
-
-  if (this._collectingContent >= 0 && (this._collectingContent - this._buffer.length) <= 0) {
-
-    this._headerData.message.content = this._buffer.slice(0, this._collectingContent);
-    this._emitMessage(this._headerData.message);
-
-    this._buffer = this._buffer.slice(this._collectingContent);
-    this._collectingContent = -1;
-
-  }
-
-  cb(null);
 };
 
 function bufferIndexOf(haystack, needle) {


### PR DESCRIPTION
The first commit may be the fix for https://github.com/stephen/airsonos/issues/38, but it's possible the reporters there are seeing a different issue.

The situation for me was that I tried to connect the default system audio output to AirSonos, which resulted in the failure popup, but also the following output on the console:

```
Received unknown RTSP method:
```

This was caused by the SETUP request. In the parsed request, the method was empty, and the request line actually ended up as the first header line. AirSonos then of course responds with 400.

Root cause was because my Mac is named "Stéphan's iMac", which is inserted in the `ANNOUNCE` right before the `SETUP`. This caused message splitting to break and the `SETUP` message to contain an extra newline at the start, which was actually part of the `ANNOUNCE` SDP.

The other commit is a fix for a theoretical stall, where a message stays unparsed in the buffer and is never emitted. (Not seen in practice.)

Tests pass.
