### PR TITLE
Fix parsing when messages contain UTF-8.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -6,7 +6,7 @@ var stream = require('stream');
 var Writable = stream.Writable;
 
 var LINE_TERMINATOR = '\r\n';
-var HEADER_TERMINATOR = '\r\n\r\n';
+var HEADER_TERMINATOR = [0x0D, 0x0A, 0x0D, 0x0A];
 
 function Parser (socket, options) {
 
@@ -67,15 +67,14 @@ Parser.prototype._write = function (chunk, encoding, cb) {
 
   this._buffer = Buffer.concat([this._buffer, chunk]);
 
-  var strBuffer = this._buffer.toString();
-  var idxTerminator = strBuffer.indexOf(HEADER_TERMINATOR);
+  var idxTerminator = bufferIndexOf(this._buffer, HEADER_TERMINATOR);
 
   if (this._collectingContent === -1 && idxTerminator !== -1) {
 
     var info;
 
     try {
-      info = this.parseHeader(strBuffer.substring(0, idxTerminator));
+      info = this.parseHeader(this._buffer.slice(0, idxTerminator).toString());
     } catch (err) {
       return cb(err);
     }
@@ -104,5 +103,19 @@ Parser.prototype._write = function (chunk, encoding, cb) {
 
   cb(null);
 };
+
+function bufferIndexOf(haystack, needle) {
+  var nLen = needle.length;
+  var max = haystack.length - nLen;
+  outer: for (var i = 0; i <= max; i++) {
+    for (var j = 0; j < nLen; j++) {
+      if (haystack[i+j] !== needle[j]) {
+        continue outer;
+      }
+    }
+    return i;
+  }
+  return -1;
+}
 
 module.exports = Parser;


### PR DESCRIPTION
From https://github.com/stephen/httplike/pull/7, quoting:

> [This] may be the fix for https://github.com/stephen/airsonos/issues/38, but it's possible the reporters there are seeing a different issue.
> 
> The situation for me was that I tried to connect the default system audio output to AirSonos, which resulted in the failure popup, but also the following output on the console:
> 
> ```
> Received unknown RTSP method:
> ```
> 
> This was caused by the SETUP request. In the parsed request, the method was empty, and the request line actually ended up as the first header line. AirSonos then of course responds with 400.
> 
> Root cause was because my Mac is named "Stéphan's iMac", which is inserted in the `ANNOUNCE` right before the `SETUP`. This caused message splitting to break and the `SETUP` message to contain an extra newline at the start, which was actually part of the `ANNOUNCE` SDP.

I also adjusted the original patch to not touch the if-statements, and basically minimized changes.

Tests pass.
